### PR TITLE
Core: Add function to get balance of a wallet address

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -44,3 +44,13 @@ func (bc *BaseClient) GetTransactionByHash(txHash string) (*types.Transaction, b
 	}
 	return tx, isPending, nil
 }
+
+// GetBalance returns the ETH balance of the given address
+func (bc *BaseClient) GetBalance(address string) (*big.Int, error) {
+	addr := common.HexToAddress(address)
+	balance, err := bc.Client.BalanceAt(context.Background(), addr, nil)
+	if err != nil {
+		return nil, err
+	}
+	return balance, nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,22 +9,15 @@ import (
 
 func main() {
 	rpc := "https://mainnet.base.org"
-	txHash := "0x8164abb7e4207cf26038299ecdb74c4a485615907368040aaf866a15c0c4c8d0"
 
 	cli, err := client.NewBaseClient(rpc)
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
 
-	tx, isPending, err := cli.GetTransactionByHash(txHash)
+	balance, err := cli.GetBalance("0x89aeE487218f9e0f986c30445A9B7ebE135c1029")
 	if err != nil {
-		log.Fatalf("Failed to fetch transaction: %v", err)
+		log.Fatal(err)
 	}
-
-	fmt.Printf("🔎 Transaction Hash: %s\n", tx.Hash().Hex())
-	fmt.Printf("📤 From: (unavailable directly, needs tx sender recovery)\n")
-	fmt.Printf("📥 To: %s\n", tx.To().Hex())
-	fmt.Printf("⛽️ Gas: %d\n", tx.Gas())
-	fmt.Printf("💰 Value: %s\n", tx.Value().String())
-	fmt.Printf("⌛ Pending: %v\n", isPending)
+	fmt.Printf("💰 Balance in wei: %s\n", balance.String())
 }


### PR DESCRIPTION
This pull request introduces a new method to retrieve the Ethereum balance of a given address and updates the main application logic to utilize this functionality instead of fetching transaction details. Below is a summary of the most important changes:

### New functionality for balance retrieval:
* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R47-R56): Added a new method `GetBalance` in the `BaseClient` class to fetch the ETH balance of a specified address using the `BalanceAt` method from the Ethereum client library.

### Updates to main application logic:
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L12-R22): Replaced the transaction-fetching logic with balance-fetching logic, including the invocation of the new `GetBalance` method and updated the output to display the balance in wei. Removed the previous code for displaying transaction details.