### PR TITLE
Core: Add function to fetch ChainID of the current connected network

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -54,3 +54,12 @@ func (bc *BaseClient) GetBalance(address string) (*big.Int, error) {
 	}
 	return balance, nil
 }
+
+// GetChainID returns the chain ID of the connected Ethereum network
+func (bc *BaseClient) GetChainID() (*big.Int, error) {
+	chainID, err := bc.Client.ChainID(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return chainID, nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,16 +8,16 @@ import (
 )
 
 func main() {
-	rpc := "https://mainnet.base.org"
+	rpc := "https://rpc.scroll.io"
 
 	cli, err := client.NewBaseClient(rpc)
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
 
-	balance, err := cli.GetBalance("0x89aeE487218f9e0f986c30445A9B7ebE135c1029")
+	chain, err := cli.GetChainID()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to get chain ID: %v", err)
 	}
-	fmt.Printf("💰 Balance in wei: %s\n", balance.String())
+	fmt.Printf("Connected to chain ID: %s\n", chain.String())
 }


### PR DESCRIPTION
This pull request introduces a new method to retrieve the chain ID of the connected Ethereum network and updates the main application logic to use this method instead of fetching a balance. Additionally, the Ethereum RPC endpoint has been updated to a new URL.

### New functionality:

* Added `GetChainID` method to `BaseClient` in `client/client.go` to retrieve the chain ID of the connected Ethereum network.

### Updates to application logic:

* Updated the main application in `cmd/main.go` to call `GetChainID` instead of `GetBalance`, and adjusted the log messages and output accordingly.

### Configuration changes:

* Changed the Ethereum RPC endpoint in `cmd/main.go` from `"https://mainnet.base.org"` to `"https://rpc.scroll.io"`.