### PR TITLE
Core: Add function to fetch block by hash

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -72,3 +72,13 @@ func (bc *BaseClient) GetBlockByNumber(blockNumber *big.Int) (*types.Block, erro
 	}
 	return block, nil
 }
+
+// GetBlockByHash fetches the block for the given hash
+func (bc *BaseClient) GetBlockByHash(blockHash string) (*types.Block, error) {
+	hash := common.HexToHash(blockHash)
+	block, err := bc.Client.BlockByHash(context.Background(), hash)
+	if err != nil {
+		return nil, err
+	}
+	return block, nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,16 +3,26 @@ package main
 import (
 	"fmt"
 	"log"
-	"math/big"
 
 	"base-devnode/client"
 )
 
 func main() {
-	rpc := "https://base.llamarpc.com"
+	rpc := "https://mainnet.base.org"
 
 	cli, err := client.NewBaseClient(rpc)
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
+
+	blockHash := "0x08322071401b3a69b00a956560393c57beaac47c7dad5adc2feae8b8f13cc253"
+
+	block, err := cli.GetBlockByHash(blockHash)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Block Number: %s\n", block.Number().String())
+	fmt.Printf("Block Hash: %s\n", block.Hash().Hex())
+	fmt.Printf("Block Transactions: %d\n", len(block.Transactions()))
 }


### PR DESCRIPTION
This pull request introduces a new method for fetching blockchain blocks by their hash and updates the main application to demonstrate its usage. The most important changes include the addition of the `GetBlockByHash` method in the `BaseClient` and modifications to the main application to utilize this new functionality.

### New functionality for fetching blocks by hash:

* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R75-R84): Added the `GetBlockByHash` method to the `BaseClient` struct, enabling retrieval of blocks using their hash. This method converts the hash string to a `HexToHash` format and fetches the block using the `BlockByHash` method from the client.

### Updates to the main application:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L6-R27): Updated the RPC URL to `https://mainnet.base.org` and added a demonstration of the `GetBlockByHash` method. The main function now fetches a block by its hash and prints the block number, hash, and transaction count.