### PR TITLE
Core: Add functions SendRawTransaction, GetTransactionReceipt and GetNonce

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -97,3 +97,13 @@ func (bc *BaseClient) SendRawTransaction(rawTxHex string) (string, error) {
 	}
 	return txHash.Hex(), nil
 }
+
+// GetTransactionReceipt fetches the receipt of a transaction by its hash
+func (bc *BaseClient) GetTransactionReceipt(txHash string) (*types.Receipt, error) {
+	hash := common.HexToHash(txHash)
+	receipt, err := bc.Client.TransactionReceipt(context.Background(), hash)
+	if err != nil {
+		return nil, err
+	}
+	return receipt, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -107,3 +107,13 @@ func (bc *BaseClient) GetTransactionReceipt(txHash string) (*types.Receipt, erro
 	}
 	return receipt, nil
 }
+
+// GetNonce returns the nonce for the given address
+func (bc *BaseClient) GetNonce(address string) (uint64, error) {
+	addr := common.HexToAddress(address)
+	nonce, err := bc.Client.NonceAt(context.Background(), addr, nil)
+	if err != nil {
+		return 0, err
+	}
+	return nonce, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -82,3 +82,18 @@ func (bc *BaseClient) GetBlockByHash(blockHash string) (*types.Block, error) {
 	}
 	return block, nil
 }
+
+// SendRawTransaction broadcasts a pre-signed raw transaction to the network
+func (bc *BaseClient) SendRawTransaction(rawTxHex string) (string, error) {
+	var txHash common.Hash
+	err := bc.Client.Client().CallContext(
+		context.Background(),
+		&txHash,
+		"eth_sendRawTransaction",
+		rawTxHex,
+	)
+	if err != nil {
+		return "", err
+	}
+	return txHash.Hex(), nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,14 +15,12 @@ func main() {
 		log.Fatalf("Failed to connect: %v", err)
 	}
 
-	blockHash := "0x08322071401b3a69b00a956560393c57beaac47c7dad5adc2feae8b8f13cc253"
+	signedTxHex := "0xf86b808504a817c80082520894f1d...etc"
 
-	block, err := cli.GetBlockByHash(blockHash)
+	txHash, err := cli.SendRawTransaction(signedTxHex)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("Broadcast failed:", err)
 	}
 
-	fmt.Printf("Block Number: %s\n", block.Number().String())
-	fmt.Printf("Block Hash: %s\n", block.Hash().Hex())
-	fmt.Printf("Block Transactions: %d\n", len(block.Transactions()))
+	fmt.Println("Transaction broadcasted! Hash:", txHash)
 }


### PR DESCRIPTION
This pull request introduces new methods to the `BaseClient` for interacting with Ethereum transactions and updates the main application logic to broadcast a signed transaction. The most important changes include adding methods for sending raw transactions, fetching transaction receipts, and retrieving account nonces, as well as modifying the main function to demonstrate broadcasting a transaction.

### New Ethereum transaction-related methods:

* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R85-R119): Added `SendRawTransaction` to broadcast a pre-signed raw transaction to the Ethereum network.
* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R85-R119): Added `GetTransactionReceipt` to fetch the receipt of a transaction using its hash.
* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R85-R119): Added `GetNonce` to retrieve the nonce for a specific Ethereum address.

### Updates to main application logic:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L18-R25): Replaced the example of fetching a block by its hash with an example of broadcasting a signed transaction using the new `SendRawTransaction` method. Updated the output to display the transaction hash upon successful broadcast.