### PR TITLE
Core: Add function to estimate gas fees before sending txs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type BaseClient struct {
@@ -116,4 +117,13 @@ func (bc *BaseClient) GetNonce(address string) (uint64, error) {
 		return 0, err
 	}
 	return nonce, nil
+}
+
+// EstimateGas estimates the gas required for a transaction
+func (bc *BaseClient) EstimateGas(msg ethereum.CallMsg) (uint64, error) {
+	gas, err := bc.Client.EstimateGas(context.Background(), msg)
+	if err != nil {
+		return 0, err
+	}
+	return gas, nil
 }


### PR DESCRIPTION
This pull request introduces a new method to estimate gas usage for transactions and reorganizes imports in the `client.go` file for better readability. Below are the key changes:

### New functionality:
* Added the `EstimateGas` method to the `BaseClient` struct to estimate the gas required for a transaction using `ethereum.CallMsg`.

### Code organization:
* Reorganized imports in `client.go` to group related packages together, ensuring better readability and maintainability.