### PR TITLE
Fix: Accept ctx context.Context in the method signatures

### DIFF
--- a/client/baseclient_test.go
+++ b/client/baseclient_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"context"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -28,7 +29,7 @@ func TestGetLatestBlockNumber(t *testing.T) {
 	cli, err := NewBaseClient(rpcURL)
 	assert.NoError(t, err)
 
-	number, err := cli.GetLatestBlockNumber()
+	number, err := cli.GetLatestBlockNumber(context.Background())
 	assert.NoError(t, err)
 	assert.True(t, number.Cmp(big.NewInt(0)) > 0)
 
@@ -40,7 +41,7 @@ func TestGetBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	addr := "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
-	balance, err := cli.GetBalance(addr)
+	balance, err := cli.GetBalance(context.Background(), addr)
 	assert.NoError(t, err)
 	assert.NotNil(t, balance)
 
@@ -51,7 +52,7 @@ func TestGetChainID(t *testing.T) {
 	cli, err := NewBaseClient(rpcURL)
 	assert.NoError(t, err)
 
-	chainID, err := cli.GetChainID()
+	chainID, err := cli.GetChainID(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, chainID)
 

--- a/client/client.go
+++ b/client/client.go
@@ -28,8 +28,8 @@ func NewBaseClient(rpcURL string) (*BaseClient, error) {
 }
 
 // GetLatestBlockNumber fetches the latest block number
-func (bc *BaseClient) GetLatestBlockNumber() (*big.Int, error) {
-	header, err := bc.Client.HeaderByNumber(context.Background(), nil)
+func (bc *BaseClient) GetLatestBlockNumber(ctx context.Context) (*big.Int, error) {
+	header, err := bc.Client.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -37,9 +37,9 @@ func (bc *BaseClient) GetLatestBlockNumber() (*big.Int, error) {
 }
 
 // GetTransactionByHash fetches a transaction and its receipt by hash
-func (bc *BaseClient) GetTransactionByHash(txHash string) (*types.Transaction, bool, error) {
+func (bc *BaseClient) GetTransactionByHash(ctx context.Context, txHash string) (*types.Transaction, bool, error) {
 	hash := common.HexToHash(txHash)
-	tx, isPending, err := bc.Client.TransactionByHash(context.Background(), hash)
+	tx, isPending, err := bc.Client.TransactionByHash(ctx, hash)
 	if err != nil {
 		return nil, false, err
 	}
@@ -47,9 +47,9 @@ func (bc *BaseClient) GetTransactionByHash(txHash string) (*types.Transaction, b
 }
 
 // GetBalance returns the ETH balance of the given address
-func (bc *BaseClient) GetBalance(address string) (*big.Int, error) {
+func (bc *BaseClient) GetBalance(ctx context.Context, address string) (*big.Int, error) {
 	addr := common.HexToAddress(address)
-	balance, err := bc.Client.BalanceAt(context.Background(), addr, nil)
+	balance, err := bc.Client.BalanceAt(ctx, addr, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -57,8 +57,8 @@ func (bc *BaseClient) GetBalance(address string) (*big.Int, error) {
 }
 
 // GetChainID returns the chain ID of the connected Ethereum network
-func (bc *BaseClient) GetChainID() (*big.Int, error) {
-	chainID, err := bc.Client.ChainID(context.Background())
+func (bc *BaseClient) GetChainID(ctx context.Context) (*big.Int, error) {
+	chainID, err := bc.Client.ChainID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +66,8 @@ func (bc *BaseClient) GetChainID() (*big.Int, error) {
 }
 
 // GetBlockByNumber fetches the block for the given number
-func (bc *BaseClient) GetBlockByNumber(blockNumber *big.Int) (*types.Block, error) {
-	block, err := bc.Client.BlockByNumber(context.Background(), blockNumber)
+func (bc *BaseClient) GetBlockByNumber(ctx context.Context, blockNumber *big.Int) (*types.Block, error) {
+	block, err := bc.Client.BlockByNumber(ctx, blockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -75,9 +75,9 @@ func (bc *BaseClient) GetBlockByNumber(blockNumber *big.Int) (*types.Block, erro
 }
 
 // GetBlockByHash fetches the block for the given hash
-func (bc *BaseClient) GetBlockByHash(blockHash string) (*types.Block, error) {
+func (bc *BaseClient) GetBlockByHash(ctx context.Context, blockHash string) (*types.Block, error) {
 	hash := common.HexToHash(blockHash)
-	block, err := bc.Client.BlockByHash(context.Background(), hash)
+	block, err := bc.Client.BlockByHash(ctx, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -85,10 +85,10 @@ func (bc *BaseClient) GetBlockByHash(blockHash string) (*types.Block, error) {
 }
 
 // SendRawTransaction broadcasts a pre-signed raw transaction to the network
-func (bc *BaseClient) SendRawTransaction(rawTxHex string) (string, error) {
+func (bc *BaseClient) SendRawTransaction(ctx context.Context, rawTxHex string) (string, error) {
 	var txHash common.Hash
 	err := bc.Client.Client().CallContext(
-		context.Background(),
+		ctx,
 		&txHash,
 		"eth_sendRawTransaction",
 		rawTxHex,
@@ -100,9 +100,9 @@ func (bc *BaseClient) SendRawTransaction(rawTxHex string) (string, error) {
 }
 
 // GetTransactionReceipt fetches the receipt of a transaction by its hash
-func (bc *BaseClient) GetTransactionReceipt(txHash string) (*types.Receipt, error) {
+func (bc *BaseClient) GetTransactionReceipt(ctx context.Context, txHash string) (*types.Receipt, error) {
 	hash := common.HexToHash(txHash)
-	receipt, err := bc.Client.TransactionReceipt(context.Background(), hash)
+	receipt, err := bc.Client.TransactionReceipt(ctx, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -110,9 +110,9 @@ func (bc *BaseClient) GetTransactionReceipt(txHash string) (*types.Receipt, erro
 }
 
 // GetNonce returns the nonce for the given address
-func (bc *BaseClient) GetNonce(address string) (uint64, error) {
+func (bc *BaseClient) GetNonce(ctx context.Context, address string) (uint64, error) {
 	addr := common.HexToAddress(address)
-	nonce, err := bc.Client.NonceAt(context.Background(), addr, nil)
+	nonce, err := bc.Client.NonceAt(ctx, addr, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"context"
 
 	"base-devnode/client"
 )
@@ -17,7 +18,7 @@ func main() {
 
 	signedTxHex := "0xf86b808504a817c80082520894f1d...etc"
 
-	txHash, err := cli.SendRawTransaction(signedTxHex)
+	txHash, err := cli.SendRawTransaction(context.Background(), signedTxHex)
 	if err != nil {
 		log.Fatal("Broadcast failed:", err)
 	}


### PR DESCRIPTION
This pull request refactors the `BaseClient` methods to consistently accept a `context.Context` parameter, improving context management and enabling better control over request lifecycles (such as timeouts and cancellations). It also updates all usages in the tests and main application to pass the required context.

**Refactoring for context support:**

* All `BaseClient` methods in `client/client.go` now accept a `context.Context` parameter, replacing internal usage of `context.Background()` with the provided context. This affects methods such as `GetLatestBlockNumber`, `GetTransactionByHash`, `GetBalance`, `GetChainID`, `GetBlockByNumber`, `GetBlockByHash`, `SendRawTransaction`, `GetTransactionReceipt`, and `GetNonce`. [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L31-R91) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L103-R115)

**Test updates:**

* All calls to `BaseClient` methods in `client/baseclient_test.go` are updated to pass `context.Background()` as the context parameter. [[1]](diffhunk://#diff-d0469d7110ec8bc1c690f5419e3f2949977df630e5e678f9210664eab5b287ccL31-R32) [[2]](diffhunk://#diff-d0469d7110ec8bc1c690f5419e3f2949977df630e5e678f9210664eab5b287ccL43-R44) [[3]](diffhunk://#diff-d0469d7110ec8bc1c690f5419e3f2949977df630e5e678f9210664eab5b287ccL54-R55)

**Main application update:**

* The call to `SendRawTransaction` in `cmd/main.go` is modified to pass `context.Background()` as the context parameter.

**Imports:**

* Added the `context` package import in files where context is now required (`client/baseclient_test.go` and `cmd/main.go`). [[1]](diffhunk://#diff-d0469d7110ec8bc1c690f5419e3f2949977df630e5e678f9210664eab5b287ccR7) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R6)