### PR TITLE
Core: Add a Close() method to properly shut down the client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,10 @@ func NewBaseClient(rpcURL string) (*BaseClient, error) {
 	}, nil
 }
 
+func (bc *BaseClient) Close() {
+    bc.Client.Close()
+}
+
 // GetLatestBlockNumber fetches the latest block number
 func (bc *BaseClient) GetLatestBlockNumber(ctx context.Context) (*big.Int, error) {
 	header, err := bc.Client.HeaderByNumber(ctx, nil)


### PR DESCRIPTION
This pull request adds a new method to the `BaseClient` struct in `client/client.go` to improve resource management. The main change is the introduction of a `Close()` method, which allows for proper cleanup of the underlying client connection.

Resource management:

* Added a `Close()` method to `BaseClient` that calls `bc.Client.Close()` to ensure the client connection is properly closed when no longer needed.