### PR TITLE
Fix: Improve error handling for better traceability

### DIFF
--- a/client/baseclient_test.go
+++ b/client/baseclient_test.go
@@ -70,7 +70,7 @@ func TestEstimateGas(t *testing.T) {
 		Data: nil,
 	}
 
-	gas, err := cli.EstimateGas(msg)
+	gas, err := cli.EstimateGas(context.Background(), msg)
 	assert.NoError(t, err)
 	assert.True(t, gas > 0)
 

--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ type BaseClient struct {
 func NewBaseClient(rpcURL string) (*BaseClient, error) {
 	client, err := ethclient.Dial(rpcURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to Ethereum client: %w", err)
 	}
 	return &BaseClient{
 		RPCURL: rpcURL,
@@ -36,7 +36,7 @@ func (bc *BaseClient) Close() {
 func (bc *BaseClient) GetLatestBlockNumber(ctx context.Context) (*big.Int, error) {
 	header, err := bc.Client.HeaderByNumber(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get latest block number: %w", err)
 	}
 	return header.Number, nil
 }
@@ -46,7 +46,7 @@ func (bc *BaseClient) GetTransactionByHash(ctx context.Context, txHash string) (
 	hash := common.HexToHash(txHash)
 	tx, isPending, err := bc.Client.TransactionByHash(ctx, hash)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("failed to get transaction: %w", err)
 	}
 	return tx, isPending, nil
 }
@@ -59,7 +59,7 @@ func (bc *BaseClient) GetBalance(ctx context.Context, address string) (*big.Int,
 	addr := common.HexToAddress(address)
 	balance, err := bc.Client.BalanceAt(ctx, addr, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get balance: %w", err)
 	}
 	return balance, nil
 }
@@ -77,7 +77,7 @@ func (bc *BaseClient) GetChainID(ctx context.Context) (*big.Int, error) {
 func (bc *BaseClient) GetBlockByNumber(ctx context.Context, blockNumber *big.Int) (*types.Block, error) {
 	block, err := bc.Client.BlockByNumber(ctx, blockNumber)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get block by number: %w", err)
 	}
 	return block, nil
 }
@@ -87,7 +87,7 @@ func (bc *BaseClient) GetBlockByHash(ctx context.Context, blockHash string) (*ty
 	hash := common.HexToHash(blockHash)
 	block, err := bc.Client.BlockByHash(ctx, hash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get block by hash: %w", err)
 	}
 	return block, nil
 }
@@ -102,7 +102,7 @@ func (bc *BaseClient) SendRawTransaction(ctx context.Context, rawTxHex string) (
 		rawTxHex,
 	)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to send raw transaction: %w", err)
 	}
 	return txHash.Hex(), nil
 }
@@ -112,7 +112,7 @@ func (bc *BaseClient) GetTransactionReceipt(ctx context.Context, txHash string) 
 	hash := common.HexToHash(txHash)
 	receipt, err := bc.Client.TransactionReceipt(ctx, hash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
 	}
 	return receipt, nil
 }
@@ -122,16 +122,16 @@ func (bc *BaseClient) GetNonce(ctx context.Context, address string) (uint64, err
 	addr := common.HexToAddress(address)
 	nonce, err := bc.Client.NonceAt(ctx, addr, nil)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get nonce: %w", err)
 	}
 	return nonce, nil
 }
 
 // EstimateGas estimates the gas required for a transaction. Call this before sending txs to get a reliable gas estimate.
-func (bc *BaseClient) EstimateGas(msg ethereum.CallMsg) (uint64, error) {
-	gas, err := bc.Client.EstimateGas(context.Background(), msg)
+func (bc *BaseClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	gas, err := bc.Client.EstimateGas(ctx, msg)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to estimate gas: %w", err)
 	}
 	return gas, nil
 }


### PR DESCRIPTION
This pull request improves error handling across the `BaseClient` implementation by wrapping errors with more descriptive messages, making debugging and maintenance easier. Additionally, it updates the `EstimateGas` method to accept a `context.Context` parameter, aligning its usage with other client methods and improving context management.

**Error handling improvements:**

* All methods in `BaseClient` now wrap returned errors with descriptive context using `fmt.Errorf`, making it easier to trace issues in logs and debugging. This affects methods such as `NewBaseClient`, `GetLatestBlockNumber`, `GetTransactionByHash`, `GetBalance`, `GetBlockByNumber`, `GetBlockByHash`, `SendRawTransaction`, `GetTransactionReceipt`, and `GetNonce`. [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L23-R23) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L39-R39) [[3]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L49-R49) [[4]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L62-R62) [[5]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L80-R80) [[6]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L90-R90) [[7]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L105-R105) [[8]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L115-R115) [[9]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L125-R134)

**API consistency and context management:**

* The `EstimateGas` method signature is updated to accept a `context.Context` parameter, replacing the previous hardcoded `context.Background()`. This change is reflected both in the method definition and its usage in tests, improving consistency and enabling better context control. [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L125-R134) [[2]](diffhunk://#diff-d0469d7110ec8bc1c690f5419e3f2949977df630e5e678f9210664eab5b287ccL73-R73)