### PR TITLE
Core: Set up block subscription for real-time monitoring

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -140,3 +140,8 @@ func (bc *BaseClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (ui
 func (bc *BaseClient) GetLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
     return bc.Client.FilterLogs(ctx, query)
 }
+
+// SubscribeNewHead subscribes to new block headers
+func (bc *BaseClient) SubscribeNewHead(ctx context.Context, ch chan *types.Header) (ethereum.Subscription, error) {
+    return bc.Client.SubscribeNewHead(ctx, ch)
+}


### PR DESCRIPTION
This pull request adds a new method to the `BaseClient` in `client/client.go` to support subscribing to new block headers. This enhances the client's functionality by allowing real-time monitoring of blockchain events.

**New feature: Block header subscription**

* Added `SubscribeNewHead` method to `BaseClient`, which enables clients to subscribe to new block headers using a channel for receiving `types.Header` updates.